### PR TITLE
Fix for updated and creating timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ composer.lock
 
 #DG specific
 */config/*
-config/*
 */cache/*
 cache/*
 */log/*

--- a/config/durc.php
+++ b/config/durc.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+
+    /**
+     * Hidden fields are database field names who's rows should be hidden on the
+     * UPDATE and CREATE view of the UI. Fields from this list are written to an array in each controller
+     * so they can be overridden. Only fields that are actually present in the model are written
+     * to the model's controller.
+     */
+    'hidden_fields' => [
+        'creation_date',
+        'created_at_date',
+        'createdAt',
+        'created_at',
+        'update_date',
+        'update_at_date',
+        'updated_date',
+        'updated_at_date',
+        'updated_at',
+        'updatedAt',
+        'update_at',
+        'deleted_at',
+        'deleted_date',
+        'deletedAt',
+    ],
+
+    /**
+     * If you want to disable the route to [baseUrl]/durctest, set this to false
+     */
+    'use_durctest_route' => true,
+
+    /**
+     * Date format to use for display (uses PHP formatting characters)
+     */
+    'date_format' => 'm/d/Y',
+    'time_format' => 'H:i',
+    'timezone' => 'America/Chicago',
+
+];

--- a/src/DURC.php
+++ b/src/DURC.php
@@ -205,9 +205,34 @@ class DURC{
             } else {
                 $formattedValue = 0;
             }
+        } else if ( $field_type == 'datetime' ) {
+            // Convert to SQL format for storage
+            $formattedValue = date( 'Y-m-d h:i:s', strtotime( $value ) );
         }
 
         return $formattedValue;
+    }
+
+    public static function formatForDisplay( $field_type, $field_name, $field_value, $is_list = false )
+    {
+        $formatted_value = '';
+
+        if ( DURC::mapColumnDataTypeToInputType( $field_type, $field_name, $field_value ) == 'boolean' ) {
+            if ( $field_value > 0 ) {
+                if ( $is_list ) {
+                    $formatted_value = '✔'; // If we are in the list view, display a checkmark
+                } else {
+                    $formatted_value = 'checked';
+                }
+            }
+        } else if ( $field_type == 'datetime' ) {
+            $formatted_value = date( config( 'durc.date_format' ).' '.config( 'durc.time_format' ), strtotime( $field_value ) );
+        } else {
+            $formatted_value = $field_value;
+        }
+
+        return $formatted_value;
+
     }
 
         public static   $column_type_map = [

--- a/src/DURCGenerator.php
+++ b/src/DURCGenerator.php
@@ -11,8 +11,29 @@ use Illuminate\Support\Facades\DB;
 */
 abstract class DURCGenerator{
 
+    //possible created_at field names...
+    //in reverse order of priority. we pick the last one.
+    protected static $valid_created_at_fields = [
+        'creation_date',
+        'created_at_date',
+        'createdAt', //Sequlize style
+        'created_at'
+    ];
 
-	//Run only once at the beginning of generation
+    //possible updated_at field names...
+    //in reverse order of priority. we pick the last one.
+    protected static $valid_updated_at_fields = [
+        'update_date',
+        'update_at_date',
+        'updated_date',
+        'updated_at_date',
+        'updated_at',
+        'updatedAt', //Sequlize style
+        'update_at',
+    ];
+
+
+    //Run only once at the beginning of generation
 	abstract public static function start(
 							$db_config,
 							$squash,
@@ -38,5 +59,42 @@ abstract class DURCGenerator{
 							$URLroot);
 
 
+    protected static function has_field( $fields, $column_name ){
+        $found = false;
+        foreach ( $fields as $field ) {
+            if ( $field['column_name'] == $column_name ) {
+                $found = true;
+                break;
+            }
+        }
+
+        return $found;
+    }
+
+    protected static function get_possible_created_at( $fields ) {
+        $created_at_field = false;
+        foreach(self::$valid_created_at_fields as $this_possible_created_at) {
+            if ( self::has_field( $fields, $this_possible_created_at ) === true ) {
+                //we found our created_at variable..
+                $created_at_field = $this_possible_created_at;
+                break;
+            }
+        }
+
+        return $created_at_field;
+    }
+
+    protected static function get_possible_updated_at( $fields ) {
+        $updated_at_field = false;
+        foreach(self::$valid_updated_at_fields as $this_possible_updated_at){
+            if ( self::has_field( $fields, $this_possible_updated_at ) === true){
+                //we found our updated_at variable..
+                $updated_at_field = $this_possible_updated_at;
+                break;
+            }
+        }
+
+        return $updated_at_field;
+    }
 
 }

--- a/src/DURCModel.php
+++ b/src/DURCModel.php
@@ -22,8 +22,6 @@ class DURCModel extends Model{
 		return($this->fresh($this->DURC_selfish_with));
 	}
 
-
-
 	public static function getNameField(){
 	
 		$my_class = get_called_class();

--- a/src/DURCMustacheGenerator.php
+++ b/src/DURCMustacheGenerator.php
@@ -69,7 +69,7 @@ class DURCMustacheGenerator{
 		$foreign_table = $field_data['foreign_table'];
 
 		$field_html = "
-  <div class='form-group row'>
+  <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-2 col-form-label'>$column_name</label>
     <div class='col-sm-10'>
 	Current id value: {{"."$column_name"."}} (see below for lookup value)<br>
@@ -113,7 +113,7 @@ $('.select2_$column_name').select2({
 		$colConv = $column_name ."Conv";
 
 		$field_html = "
-  <div class='form-group row'>
+  <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-2 col-form-label'>$column_name</label>
     <div class='col-sm-10'>
       <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}'>
@@ -161,7 +161,7 @@ $('.select2_$column_name').select2({
 		$colConv = $column_name ."Conv";
 
 		$field_html = "
-  <div class='form-group row'>
+  <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-2 col-form-label'>$column_name</label>
     <div class='col-sm-10'>
       <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}'>
@@ -208,7 +208,7 @@ $('.select2_$column_name').select2({
 
 	
 		$field_html = "
-  <div class='form-group row'>
+  <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-2 col-form-label'>$column_name</label>
     <div class='col-sm-10'>
       <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}'>
@@ -230,11 +230,11 @@ $('.select2_$column_name').select2({
         $foreign_table = $field_data['foreign_table'];
 
         $field_html = "
-  <div class='form-group row'>
+  <div class='form-group row {{"."$column_name"."_row_class}}'>
     <div class='col-sm-2'><label>$column_name</label></div>
     <div class='col-sm-10'>
         <div class='checkbox'>
-            <input type='checkbox' id='$column_name' name='$column_name' {{"."$column_name"."_checkbox}} >
+            <input type='checkbox' id='$column_name' name='$column_name' {{"."$column_name"."}} >
        </div> 
     </div>
   </div>

--- a/src/DURCServiceProvider.php
+++ b/src/DURCServiceProvider.php
@@ -18,6 +18,9 @@ class DURCServiceProvider extends ServiceProvider
 
     public function register()
     {
+        // Load the durc config file and merge it with the user's
+        $this->mergeConfigFrom( base_path( 'vendor/careset/durc/config/durc.php' ), 'durc' );
+
             $this->commands([
                 DURCCommand::class,
                 DURCMineCommand::class,
@@ -31,7 +34,8 @@ class DURCServiceProvider extends ServiceProvider
                 require base_path( 'routes/web.durc.php' );
             }
 
-            if ( file_exists( base_path( 'routes/durc_test.php' ) ) ) {
+            if ( config( 'durc.use_durctest_route' ) == true  &&
+                file_exists( base_path( 'routes/durc_test.php' ) ) ) {
                 require base_path( 'routes/durc_test.php' );
             }
         });

--- a/src/Generators/LaravelControllerGenerator.php
+++ b/src/Generators/LaravelControllerGenerator.php
@@ -347,7 +347,8 @@ $with_summary_array_code
 
 		//put the contents into the view...
 		foreach(\$$class_name"."->toArray() as \$key => \$value){
-			if ( DURC::mapColumnDataTypeToInputType( \$$class_name::\$field_type_map[\$key], \$key, \$value ) == 'boolean' ) {
+			if ( isset(\$$class_name::\$field_type_map[\$key]) &&
+			    DURC::mapColumnDataTypeToInputType( \$$class_name::\$field_type_map[\$key], \$key, \$value ) == 'boolean' ) {
                 if ( \$value > 0 ) {
                     \$this->view_data[ \$key . '_checkbox' ] = 'checked';
                 }

--- a/src/Generators/LaravelControllerGenerator.php
+++ b/src/Generators/LaravelControllerGenerator.php
@@ -32,6 +32,16 @@ class LaravelControllerGenerator extends \CareSet\DURC\DURCGenerator {
 		//terrible idea. Forces contstant git changes for no actual code change.
                 $gen_string = DURC::get_gen_string();
 
+        // Write the hidden fields
+        $hidden_fields_array_code = "\tprotected static \$hidden_fields_array = [\n";
+        $hiddenFields = config( 'durc.hidden_fields' );
+        foreach ( $hiddenFields as $hiddenField ) {
+            if ( self::has_field( $fields, $hiddenField ) ) {
+                $hidden_fields_array_code .= "\t\t'$hiddenField',\n";
+            }
+        }
+        $hidden_fields_array_code .= "\n\t];\n";
+
 		$others = [];
 		if(!is_null($belongs_to)){
 			foreach($belongs_to as $rel => $belongs_to_data){
@@ -39,76 +49,34 @@ class LaravelControllerGenerator extends \CareSet\DURC\DURCGenerator {
 			}
 		}
 
-		$with_summary_array_code = "\t\t\$with_summary_array = [];\n";;
+		$with_summary_array_code = "\t\t\$with_summary_array = [];\n";
 		foreach($others as $rel => $table_type){
 			//why does this fail?
 			$with_summary_array_code .= "\t\t\$with_summary_array[] = \"$rel:id,\".\App\\$table_type::getNameField();\n";
 			//$with_summary_array_code .= "\t\t\$with_summary_array[] = '$rel';\n";
 		}
-		
-
-
-
-		//possible created_at field names... 
-		//in reverse order of priority. we pick the last one.
-		$valid_created_at_fields = [
-			'creation_date',
-			'created_at_date',
-			'createdAt', //Sequlize style
-			'created_at',
-			];
-
-		//possible updated_at field names... 
-		//in reverse order of priority. we pick the last one.
-                $valid_updated_at_fields = [
-                        'update_date',
-                        'update_at_date',
-                        'updated_date',
-                        'updated_at_date',
-			'updated_at',
-			'updatedAt', //Sequlize style
-                        'update_at',
-                        ];
-
-
-		$updated_at_code = null;	
-		$created_at_code = null;	
-		
-		foreach($valid_created_at_fields as $this_possible_created_at){
-			if(isset($fields[$this_possible_created_at])){
-				//we found our created_at variable..
-				$created_at_code = "const CREATED_AT = '$this_possible_created_at'"; 	
-			}
-		}	
-		foreach($valid_updated_at_fields as $this_possible_updated_at){
-			if(isset($fields[$this_possible_updated_at])){
-				//we found our created_at variable..
-				$updated_at_code = "const UPDATED_AT = '$this_possible_updated_at'"; 	
-			}
-		}	
-
-		//we should do more logic to support dateformat laravel here...
-
-
-		if(is_null($updated_at_code) || is_null($created_at_code)){ //we must have both...
-			$timestamp_code = "public \$timestamps = false;";
-			$updated_at_code = '//DURC NOTE: did not find updated_at and created_at fields for this model' ."\n";
-			$created_at_code = '';
-		}
-
 
 		$parent_class_name = "$class_name";
 
 		$parent_file_name = "$parent_class_name"."Controller.php";	
 		$child_file_name = "$class_name"."Controller.php";	
 
-	$field_update_from_request = '';
-	foreach($fields as $field_data){
-			$this_field = $field_data['column_name'];
-			$data_type = $field_data['data_type'];
-			$field_update_from_request .= "		\$tmp_$class_name"."->$this_field = DURC::formatForStorage( '$this_field', '$data_type', \$request->$this_field ); \n";
-	}	
-	$field_update_from_request .= "		\$tmp_$class_name"."->save();\n";
+		$possible_updated_at_field = self::get_possible_updated_at( $fields );
+		$possible_created_at_field = self::get_possible_created_at( $fields );
+        $field_update_from_request = '';
+        foreach($fields as $field_data){
+            $this_field = $field_data['column_name'];
+
+            // Don't write explicit variable assignments for timestamps
+            if ( $possible_updated_at_field == $this_field ||
+                $possible_created_at_field == $this_field ) {
+                continue;
+            }
+
+            $data_type = $field_data['data_type'];
+            $field_update_from_request .= "		\$tmp_$class_name"."->$this_field = DURC::formatForStorage( '$this_field', '$data_type', \$request->$this_field ); \n";
+        }
+        $field_update_from_request .= "		\$tmp_$class_name"."->save();\n";
 
 
 		$parent_class_text = "<?php
@@ -127,6 +95,7 @@ class $class_name"."Controller extends DURCController
 
 	public \$view_data = [];
 
+$hidden_fields_array_code
 
 	public function getWithArgumentArray(){
 		
@@ -148,7 +117,35 @@ $with_summary_array_code
 			\$return_me[\$key] = \$value;
         	}
 
-		//collapse joined data..
+		//collapse and format joined data..
+		\$return_me_data = [];
+        foreach(\$return_me['data'] as \$data_i => \$data_row){
+                foreach(\$data_row as \$key => \$value){
+                        if(is_array(\$value)){
+                                foreach(\$value as \$lowest_key => \$lowest_data){
+                                        //then this is a loaded attribute..
+                                        //lets move it one level higher...
+
+                                        if ( isset( $class_name::\$field_type_map[\$lowest_key] ) ) {
+                                            \$field_type = $class_name::\$field_type_map[ \$lowest_key ];
+                                            \$return_me_data[\$data_i][\$key .'_id_DURClabel'] = DURC::formatForDisplay( \$field_type, \$lowest_key, \$lowest_data, true );
+                                        } else {
+                                            \$return_me_data[\$data_i][\$key .'_id_DURClabel'] = \$lowest_data;
+                                        }
+                                }
+                        }
+
+                        if ( isset( $class_name::\$field_type_map[\$key] ) ) {
+                            \$field_type = $class_name::\$field_type_map[ \$key ];
+                            \$return_me_data[\$data_i][\$key] = DURC::formatForDisplay( \$field_type, \$key, \$value, true );
+                        } else {
+                            \$return_me_data[\$data_i][\$key] = \$value;
+                        }
+                }
+        }
+        \$return_me['data'] = \$return_me_data;
+		
+		
                 foreach(\$return_me['data'] as \$data_i => \$data_row){
                         foreach(\$data_row as \$key => \$value){
                                 if(is_array(\$value)){
@@ -339,6 +336,15 @@ $with_summary_array_code
 	}
 
 	\$this->view_data['csrf_token'] = csrf_token();
+	
+	
+	foreach ( $class_name::\$field_type_map as \$column_name => \$field_type ) {
+        // If this field name is in the configured list of hidden fields, do not display the row.
+        \$this->view_data[\"{\$column_name}_row_class\"] = '';
+        if ( in_array( \$column_name, self::\$hidden_fields_array ) ) {
+            \$this->view_data[\"{\$column_name}_row_class\"] = 'd-none';
+        }
+    }
 
 	if(\$$class_name"."->exists){	//we will not have old data if this is a new object
 
@@ -347,14 +353,11 @@ $with_summary_array_code
 
 		//put the contents into the view...
 		foreach(\$$class_name"."->toArray() as \$key => \$value){
-			if ( isset(\$$class_name::\$field_type_map[\$key]) &&
-			    DURC::mapColumnDataTypeToInputType( \$$class_name::\$field_type_map[\$key], \$key, \$value ) == 'boolean' ) {
-                if ( \$value > 0 ) {
-                    \$this->view_data[ \$key . '_checkbox' ] = 'checked';
-                }
+			if ( isset( $class_name::\$field_type_map[\$key] ) ) {
+                \$field_type = $class_name::\$field_type_map[ \$key ];
+                \$this->view_data[\$key] = DURC::formatForDisplay( \$field_type, \$key, \$value );
             } else {
-
-                \$this->view_data[ \$key ] = \$value;
+                \$this->view_data[\$key] = \$value;
             }
 		}
 

--- a/src/Generators/LaravelEloquentGenerator.php
+++ b/src/Generators/LaravelEloquentGenerator.php
@@ -36,48 +36,33 @@ class LaravelEloquentGenerator extends \CareSet\DURC\DURCGenerator {
 
                 $gen_string = DURC::get_gen_string();
 
-		//possible created_at field names... 
-		//in reverse order of priority. we pick the last one.
-		$valid_created_at_fields = [
-			'creation_date',
-			'created_at_date',
-			'createdAt', //Sequlize style
-			'created_at',
-			];
-
-		//possible updated_at field names... 
-		//in reverse order of priority. we pick the last one.
-                $valid_updated_at_fields = [
-                        'update_date',
-                        'update_at_date',
-                        'updated_date',
-                        'updated_at_date',
-			'updated_at',
-			'updatedAt', //Sequlize style
-                        'update_at',
-                        ];
 
 
 		$updated_at_code = null;	
-		$created_at_code = null;	
-		
-		foreach($valid_created_at_fields as $this_possible_created_at){
-			if(isset($fields[$this_possible_created_at])){
-				//we found our created_at variable..
-				$created_at_code = "const CREATED_AT = '$this_possible_created_at'"; 	
-			}
-		}	
-		foreach($valid_updated_at_fields as $this_possible_updated_at){
-			if(isset($fields[$this_possible_updated_at])){
-				//we found our created_at variable..
-				$updated_at_code = "const UPDATED_AT = '$this_possible_updated_at'"; 	
-			}
-		}	
+		$created_at_code = null;
+
+        $this_possible_created_at = self::get_possible_created_at( $fields );
+        if ( $this_possible_created_at !== false ) {
+            //we found our created_at variable..
+            $created_at_code = "const CREATED_AT = '$this_possible_created_at';";
+        } else {
+            $created_at_code = "const CREATED_AT = null;";
+        }
+
+        $this_possible_updated_at = self::get_possible_updated_at( $fields );
+		if ( $this_possible_updated_at !== false ) {
+            //we found our created_at variable..
+            $updated_at_code = "const UPDATED_AT = '$this_possible_updated_at';";
+		} else {
+            $updated_at_code = "const UPDATED_AT = null;";
+        }
 
 		//we should do more logic to support dateformat laravel here...
 
-
-		if(is_null($updated_at_code) || is_null($created_at_code)){ //we must have both...
+        $timestamp_code = "public \$timestamps = true;";
+		if($this_possible_updated_at === false &&
+            $this_possible_created_at === false ){
+		    // We don't have either timestamp
 			$timestamp_code = "public \$timestamps = false;";
 			$updated_at_code = '//DURC NOTE: did not find updated_at and created_at fields for this model' ."\n";
 			$created_at_code = '';

--- a/test_mywind_database/aaaDurctest.sql
+++ b/test_mywind_database/aaaDurctest.sql
@@ -147,26 +147,50 @@ UNLOCK TABLES;
 --
 -- Table structure for table `booleantest`
 --
-LOCK TABLES `booleantest` WRITE;
-CREATE TABLE `booleantest` (
-  `id` int(11) NOT NULL,
+DROP TABLE IF EXISTS `test_boolean`;
+
+CREATE TABLE `test_boolean` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
   `label` varchar(255) NOT NULL,
   `is_something` varchar(255) NOT NULL,
   `has_something` varchar(255) NOT NULL,
   `is_something2` tinyint(4) DEFAULT NULL,
   `has_something2` tinyint(4) DEFAULT NULL,
-  `has_something3` tinyint(1) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
-UNLOCK TABLES;
+  `has_something3` tinyint(1) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=latin1;
 
 --
 -- Dumping data for table `booleantest`
 --
 
-INSERT INTO `booleantest` (`id`, `label`, `is_something`, `has_something`, `is_something2`, `has_something2`, `has_something3`) VALUES
+LOCK TABLES `test_boolean` WRITE;
+INSERT INTO `test_boolean` (`id`, `label`, `is_something`, `has_something`, `is_something2`, `has_something2`, `has_something3`) VALUES
 (1, 'Test checkbox', 'yes', '1', 1, 0, 1),
 (2, 'Test checkbox', '2', 'no', 0, 2, 0);
+UNLOCK TABLES;
 
+--
+-- Table structure for table `test_created_only`
+--
+DROP TABLE IF EXISTS `test_created_only`;
+
+CREATE TABLE `test_created_only` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) DEFAULT NULL,
+  `created_at` datetime NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `test_created_only`
+--
+
+LOCK TABLES `test_created_only` WRITE;
+INSERT INTO `test_created_only` (`id`, `name`, `created_at`) VALUES
+(1, 'Test 1', '2018-02-22 00:00:00'),
+(2, 'Test 2', '2018-02-21 00:00:00');
+UNLOCK TABLES;
 
 --
 -- Table structure for table `comment`


### PR DESCRIPTION
*fixed updated and created timestamps so they are managed by laravel updated/create events
*works if you just have created timestamps and not updated, and added test SQL for that
*added config file with hidden fields
*config hidden fields are written to controller during generation so they can be overridden
*hidden fields are hidden on DOM only
*and added date formatting to durc config to edit and list views
*refactored some code into functions related to checkboxes and display checkmark on list view if *checked
(#21) (#33) (#4)