### PR TITLE
Add null checkbox and behavior for null and default values (#48)(#28)

### DIFF
--- a/src/DURCModel.php
+++ b/src/DURCModel.php
@@ -13,6 +13,10 @@ use Illuminate\Database\Eloquent\Model;
 */
 class DURCModel extends Model{
 
+    // By default, all fields are nullable, but this is overriddedn in child classes
+    // Depending on what is mined from the database shcema
+    protected $non_nullable_fields = [];
+
 	/**
 	*	This function allows us to avoid the recursive eager loading problem by allowing a controller (etc) to specify
  	*	That only one level of eager loading will occur, starting from the object-in-focus...
@@ -21,6 +25,39 @@ class DURCModel extends Model{
 	public function fresh_with_relations(){
 		return($this->fresh($this->DURC_selfish_with));
 	}
+
+	public function isFieldNullable($field)
+    {
+        $nullable = true;
+        // See if this field name is in the array of non-nullable fields
+        if (in_array($field, $this->non_nullable_fields)) {
+            $nullable = false;
+        }
+
+        return $nullable;
+    }
+
+    public function getNullableFields()
+    {
+        $nullable = [];
+        foreach($this->attributes as $key => $value) {
+            if ($this->isFieldNullable($key)) {
+                $nullable[]= $key;
+            }
+        }
+
+        return $nullable;
+    }
+
+    public function getDefautValue($field)
+    {
+        $default = null;
+        if (array_key_exists($field, $this->attributes)) {
+            $default = $this->attributes[$field];
+        }
+
+        return $default;
+    }
 
 	//overriding this can change how a card_body is calculated in the json for single data option..
 	public function getCardBody(){

--- a/src/DURCMustacheGenerator.php
+++ b/src/DURCMustacheGenerator.php
@@ -88,6 +88,58 @@ class DURCMustacheGenerator extends DURCGenerator {
 
 	}
 
+	protected static function _get_default_value($field_data)
+    {
+        $default_value = null;
+        if ((isset($field_data['default_value']) &&
+                $field_data['default_value'] !== null)) {
+            $default_value = $field_data['default_value'];
+        }
+
+        return $default_value;
+    }
+
+    protected static function _is_nullable($field_data)
+    {
+        $is_nullable = false;
+        if ((isset($field_data['is_nullable']) &&
+            $field_data['is_nullable'] !== null)) {
+            $is_nullable = $field_data['is_nullable'];
+        }
+
+        return $is_nullable;
+    }
+
+    protected static function _is_required($field_data)
+    {
+        $required = false;
+        if (self::_is_nullable($field_data) === false &&
+            self::_get_default_value($field_data) === null) {
+            $required = true;
+        }
+
+        // Make an exception for auto-increment fields, because they populate automatically
+        if (isset($field_data['is_auto_increment']) &&
+            $field_data['is_auto_increment'] === true) {
+            $required = false;
+        }
+
+        return $required;
+    }
+
+    protected static function _get_null_checkbox_elem($field_data)
+    {
+        $column_name = $field_data['column_name'];
+
+        // This is the checkbox element
+        $html = "<div class='col-sm-1'>
+                    <input class='form-check-input null-checkbox' type='checkbox' data-elem='{$column_name}' name='{$column_name}Null' id='{$column_name}Null' value='{$column_name}Null' {{{$column_name}_checked}}>
+                    <label class='form-check-label' for='{$column_name}Null'>null</label>
+                </div>";
+
+        return $html;
+    }
+
 	//this returns both the html and the javascript required to kick start an AJAX powered select2 instance.
 	public static function _get_select2_field_html($URLroot, $field_data){
 
@@ -109,7 +161,7 @@ class DURCMustacheGenerator extends DURCGenerator {
 		$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
 	Current id value: {{"."$column_name"."}} (see below for lookup value)<br>
 	<select class='select2_$column_name form-control' id='$column_name' name='$column_name' $maybe_disabled_html >
 	<option value='{{"."$column_name"."}}' selected='selected'>{{"."$column_name"."}}</option>
@@ -172,7 +224,7 @@ $('.select2_$column_name').select2({
 		$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
       <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}' $maybe_readonly_html >
 
 <button type='button' class='btn btn-primary' id='$icon_id'>
@@ -229,7 +281,7 @@ $('.select2_$column_name').select2({
 		$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
       <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}' $maybe_readonly_html >
 
 <button type='button' class='btn btn-primary' id='$icon_id'>
@@ -301,7 +353,7 @@ $('.select2_$column_name').select2({
 			$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
 	<pre>>{{"."$column_name"."}}</pre>
     </div>
   </div>	";
@@ -312,7 +364,7 @@ $('.select2_$column_name').select2({
 			$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
 	<textarea style='height: auto;'  id='$column_name' name='$column_name' >{{"."$column_name"."}}
 
 </textarea>
@@ -355,7 +407,7 @@ $('.select2_$column_name').select2({
 			$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
 	<pre>{{"."$column_name"."}}</pre>
     </div>
   </div>
@@ -366,7 +418,7 @@ $('.select2_$column_name').select2({
 			$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
 	<textarea id='$column_name' name='$column_name'  >{{"."$column_name"."}}</textarea>
     </div>
   </div>
@@ -393,6 +445,15 @@ $('.select2_$column_name').select2({
 		$foreign_db = $field_data['foreign_db'];
 		$foreign_table = $field_data['foreign_table'];
 
+        // Get our default value, if there is one, so we can put it in the placeholder,
+        $default_value = self::_get_default_value($field_data);
+
+        // If we don't have a default value, and this field is not nullable, we have to make it required,
+        $required = '';
+        if (self::_is_required($field_data) === true) {
+            $required = 'required';
+        }
+
 		$is_view_only = $field_data['is_view_only'];
 	
 		if($is_view_only){
@@ -404,11 +465,16 @@ $('.select2_$column_name').select2({
 		$field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <label for='$column_name' class='col-sm-4 col-form-label'>$column_name</label>
-    <div class='col-sm-8'>
-      <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='' value='{{"."$column_name"."}}' $maybe_readonly_html>
-    </div>
-  </div>
-";
+    <div class='col-sm-7'>
+      <input type='text' class='form-control' id='$column_name' name='$column_name' placeholder='$default_value' value='{{"."$column_name"."}}' $maybe_readonly_html $required>
+    </div>";
+		if (self::_is_nullable($field_data)) {
+		    // If we have a nullable field, add the null checkbox
+            $field_html .= self::_get_null_checkbox_elem($field_data);
+		}
+
+
+        $field_html .="</div>";
 
 		return($field_html);
 	}
@@ -435,7 +501,7 @@ $('.select2_$column_name').select2({
         $field_html = "
   <div class='form-group row {{"."$column_name"."_row_class}}'>
     <div class='col-sm-4'><label>$column_name</label></div>
-    <div class='col-sm-8'>
+    <div class='col-sm-7'>
         <div class='checkbox'>
             <input type='checkbox' id='$column_name' name='$column_name' {{"."$column_name"."}} $maybe_readonly_html >
        </div> 

--- a/src/Generators/LaravelEloquentGenerator.php
+++ b/src/Generators/LaravelEloquentGenerator.php
@@ -281,7 +281,38 @@ class $parent_class_name extends DURCModel{
 
 
 		$parent_class_code .= "			]; //end field_type_map
+		
+    // Indicate which fields are nullable for the UI to be able to validate required form elements
+    protected \$non_nullable_fields = [
+";
+        foreach($fields as $field_index => $field_data) {
+            // If the field can be NULL, add to this array
+            if (array_key_exists('is_nullable', $field_data) &&
+                $field_data['is_nullable'] === false) {
+                $this_field = $field_data['column_name'];
+                $parent_class_code .= "		'$this_field',\n";
+            }
+		}
+        $parent_class_code .= "			]; // End of nullable fields
 
+    // Use Eloquent attributes array to specify the default values for each field (if any) indicated by the DB schema, to be used as placeholder on form elements
+    protected \$attributes = [
+";
+        foreach($fields as $field_index => $field_data) {
+            // If the field has a default value, add it to this array
+            if (array_key_exists('default_value', $field_data)) {
+                $default_value = $field_data['default_value'];
+                $this_field = $field_data['column_name'];
+                if ($default_value === null) {
+                    $parent_class_code .= "		'$this_field' => null,\n";
+                } else {
+                    $parent_class_code .= "		'$this_field' => '$default_value',\n";
+                }
+
+            }
+		}
+        $parent_class_code .= "			]; // End of attributes
+        
 		//everything is fillable by default
 		protected \$guarded = [];
 

--- a/src/Generators/MustacheEditViewGenerator.php
+++ b/src/Generators/MustacheEditViewGenerator.php
@@ -367,6 +367,39 @@ $template_text .= "
 
 	$template_text .= "
 <br>
+    
+    <script type='text/javascript'>
+    // This javascript controls the null checkboxes
+        $(document).ready(function() {
+            
+            // keep an assoc array of the last entered values
+            let last_null_values = {};
+            
+            $('.null-checkbox').change(function(e) {
+
+                // get the id of the element we're next to
+                let id = $(this).attr('data-elem');
+
+                // store current value, and set to null
+                if ($(this).prop('checked')) {
+                    last_null_values[id]= $('#'+id).val();
+                    $('#'+id).val(null);
+                    $('#'+id).attr('readonly', true);
+                } else {
+                    $('#'+id).val(last_null_values[id]);
+                    $('#'+id).attr('readonly', false);
+                }
+            });
+            
+            // Trigger change on page load
+            $('.null-checkbox').each(function() {
+                if ($(this).prop('checked')) {
+                    let id = $(this).attr('data-elem');
+                    $('#'+id).attr('readonly', true);
+                }
+            });
+        });
+    </script>
 ";
 
 		$my_path = base_path() . "/resources/views/DURC/$class_name/";

--- a/src/Generators/MySQLDumpGenerator.php
+++ b/src/Generators/MySQLDumpGenerator.php
@@ -47,7 +47,7 @@ class MySQLDumpGenerator extends \CareSet\DURC\DURCGenerator {
 		
 			//sed command removes autoincriment.. which will constantly result in new file structure as data is added...
 			//from https://stackoverflow.com/a/26328331/144364
-			$mysqldump_command = "mysqldump -u $user -p$password --no-data --compact $database $table | sed 's/ AUTO_INCREMENT=[0-9]*//g' > $file_path";
+			$mysqldump_command = "/Applications/MAMP/Library/bin/mysqldump -u $user -p$password --no-data --compact $database $table | sed 's/ AUTO_INCREMENT=[0-9]*//g' > $file_path";
 			
 			exec($mysqldump_command);
 

--- a/test_databases/DURC_aaa.sql
+++ b/test_databases/DURC_aaa.sql
@@ -433,6 +433,47 @@ INSERT INTO `test_created_only` VALUES (1,'Test 1','2018-02-22 00:00:00'),(2,'Te
 UNLOCK TABLES;
 
 --
+-- Table structure for table `test_null_default`
+--
+
+CREATE TABLE `test_null_default` (
+  `id` int(11) NOT NULL,
+  `null_var` varchar(255) DEFAULT NULL,
+  `non_null_var_def` varchar(255) NOT NULL,
+  `non_null_var_no_def` varchar(255) DEFAULT NULL,
+  `nullable_w_default` varchar(255) DEFAULT 'THIS IS THE DEFAULT',
+  `non_null_default` varchar(255) NOT NULL DEFAULT 'I CANNOT BE NULL'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--
+-- Dumping data for table `test_null_default`
+--
+LOCK TABLES `test_null_default` WRITE;
+INSERT INTO `test_null_default` (`id`, `null_var`, `non_null_var_def`, `non_null_var_no_def`, `nullable_w_default`, `non_null_default`) VALUES
+(1, 'three', 'smelly', 'four', 'THIS IS THE DEFAULT', 'I CANNOT BE NULL'),
+(2, NULL, 'non null', NULL, 'THIS IS THE DEFAULT', 'I CANNOT BE NULL');
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `test_null_default`
+--
+ALTER TABLE `test_null_default`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `test_null_default`
+--
+ALTER TABLE `test_null_default`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+UNLOCK TABLES;
+--
 -- Table structure for table `vote`
 --
 


### PR DESCRIPTION
This PR adds a null checkbox to the text input fields for fields that are nullable. This requires re-mining database.

- When database field is nullable, display a null checkbox, which is checked if the value is null and makes text input readonly
- Uses default value as defined in database if there is one
- If field cannot be null, and has no default, field is required
- If field is auto-increment, is not required

<img width="1294" alt="Screen Shot 2020-01-31 at 12 01 26 PM" src="https://user-images.githubusercontent.com/271809/73559348-dcab1d80-4422-11ea-8b66-b2fba0a9f752.png">
